### PR TITLE
fix(l10n): correct Spanish string resource errors

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -269,10 +269,10 @@
     <string name="sunken_outpost">Puesto hundido</string>
     <string name="the_frowning_gate">La Puerta Ceñida</string>
     <string name="bowl_of_the_sun">Recipiente del Sol</string>
-    <string name="the_alluvial_ruins">Ruinas aluviales</string>
+    <string name="the_alluvial_ruins">Ruinas Aluviales</string>
     <string name="the_tumbledown">Batacazo</string>
     <string name="watchers_rock">Roca del Vigilante</string>
-    <string name="archeological_outpost">Puesto Arqeulógico</string>
+    <string name="archeological_outpost">Puesto Arcológico</string>
     <string name="rings_of_the_moon">Anillos de la Luna</string>
     <string name="the_concordant_ziggurats">Los Zigurats Conexos</string>
     <string name="meadow">Prado</string>


### PR DESCRIPTION
Corrects a typo in the Spanish translation for 'archeological_outpost', changing 'Arqeulógico' to 'Arcológico'. Additionally, adjusts the capitalization of 'Ruinas aluviales' to 'Ruinas Aluviales' for improved consistency.